### PR TITLE
Fix redirects without https

### DIFF
--- a/app/Http/Middleware/VerifyUserLogged.php
+++ b/app/Http/Middleware/VerifyUserLogged.php
@@ -15,10 +15,14 @@ class VerifyUserLogged
      */
     public function handle($request, Closure $next)
     {
-        if (Auth::guest()) {
-            return redirect()->secure('/login');
+        if (Auth::check()) {
+            return $next($request);
         }
 
-        return $next($request);
+        if (env('APP_ENV') === 'local') {
+            return redirect('/login');
+        }
+
+        return redirect()->secure('/login');
     }
 }

--- a/app/Http/Middleware/VerifyUserLogged.php
+++ b/app/Http/Middleware/VerifyUserLogged.php
@@ -16,7 +16,7 @@ class VerifyUserLogged
     public function handle($request, Closure $next)
     {
         if (Auth::guest()) {
-            return redirect('/login');
+            return redirect()->secure('/login');
         }
 
         return $next($request);


### PR DESCRIPTION
As detected on #23, when a guest tries to access a page that requires authentication and is redirected to login page, the application is losing https protocol.

For now, this will affect only the non-local environments.